### PR TITLE
Sensors and commands parsing

### DIFF
--- a/inc/sensors.h
+++ b/inc/sensors.h
@@ -1,0 +1,35 @@
+/*
+ * sensors.h
+ *
+ *  Created on: May 11, 2018
+ *      Author: Poornachander
+ */
+
+#ifndef SENSORS_H_
+#define SENSORS_H_
+
+typedef enum battery {
+	Left_Battery = 1,
+	Right_Battery
+} battery_t;
+
+
+extern uint16_t Get_Battery_Voltage(battery_t battery);
+
+extern uint16_t Get_Battery_Current(battery_t battery);
+
+extern uint16_t Get_System_Current();
+
+extern uint16_t Get_Motors_Current();
+
+extern uint16_t Get_External_Pressure();
+
+extern uint16_t Get_Internal_Pressure();
+
+extern uint16_t Get_Temperature();
+
+extern uint16_t Get_Humidity();
+
+extern uint16_t Get_Water_Sensor_Value();
+
+#endif /* SENSORS_H_ */

--- a/src/FSM.c
+++ b/src/FSM.c
@@ -19,26 +19,6 @@ extern void FSM(void *dummy){
 	//initialize the UART
 	UART_init();
 
-	//For debugging only
-	while(1) {
-		uint16_t pressure = Get_External_Pressure();
-
-		//For debugging only
-		char output[6];
-		itoa(pressure, output, 10);
-//		UART_push_out_len(output, 5);
-//		UART_push_out("\r\n");
-
-		pressure = Get_ADC_Channel(ADC_Pressure_Sensor);
-		pressure = pressure * (float)3300/4095;
-		//For debugging only
-		itoa(pressure, output, 10);
-		UART_push_out_len(output, 5);
-		UART_push_out("\r\n");
-
-		vTaskDelay(500);
-	}
-
 	inputBuffer.size = 0;
 
 	//Stores the current command
@@ -61,8 +41,8 @@ extern void FSM(void *dummy){
 			UART_push_out("\r\n");
 		}
 
-		//Not working at the moment
-#warning "CRx command does not work yet. ADC value too high"
+		//Hardware issue with op-amp causes values below 45mV and values above 2.75V to return incorrect ADC values.
+		//This shouldn't be a problem with normal operation. Only with very low currents.
 		//CRx command
 		else if(strncmp(commandString, "CR", 2) == 0) {
 			uint16_t current = 0; //Current in mA
@@ -87,13 +67,7 @@ extern void FSM(void *dummy){
 
 			}
 
-//			UART_push_out_len((char *)&current, 2);
-//			UART_push_out("\r\n");
-
-			//For debugging only
-			char output[6];
-			itoa(current, output, 10);
-			UART_push_out_len(output, 5);
+			UART_push_out_len((char *)&current, 2);
 			UART_push_out("\r\n");
 
 		}
@@ -142,6 +116,7 @@ extern void FSM(void *dummy){
 
 		}
 
+		//Hardware issue with op-amp causes values below 45mV and values above 2.75V to return incorrect ADC values.
 		//WTH
 		else if(strcmp(commandString, "WTH") == 0){
 			char bufs[5];
@@ -151,6 +126,7 @@ extern void FSM(void *dummy){
 			UART_push_out_len("\r\n", 2);
 		}
 
+		//Hardware issue with op-amp causes values below 45mV and values above 2.75V to return incorrect ADC values.
 		//WTR
 		else if(strcmp(commandString, "WTR") == 0){
 			uint16_t pressure = Get_Water_Sensor_Value();
@@ -163,6 +139,7 @@ extern void FSM(void *dummy){
 
 		}
 
+		//Hardware issue with op-amp causes values below 45mV and values above 2.75V to return incorrect ADC values.
 		//PEX command
 		else if (strcmp(commandString, "PEX") == 0) {
 			uint16_t pressure = Get_External_Pressure();

--- a/src/FSM.c
+++ b/src/FSM.c
@@ -10,12 +10,34 @@
 #include "task.h"
 #include "ADC.h"
 #include "sensors.h"
+#include <stdlib.h>
+#include <stdio.h>
 
 #define CHAR_TO_INT (48)
 
 extern void FSM(void *dummy){
 	//initialize the UART
 	UART_init();
+
+	//For debugging only
+	while(1) {
+		uint16_t pressure = Get_External_Pressure();
+
+		//For debugging only
+		char output[6];
+		itoa(pressure, output, 10);
+//		UART_push_out_len(output, 5);
+//		UART_push_out("\r\n");
+
+		pressure = Get_ADC_Channel(ADC_Pressure_Sensor);
+		pressure = pressure * (float)3300/4095;
+		//For debugging only
+		itoa(pressure, output, 10);
+		UART_push_out_len(output, 5);
+		UART_push_out("\r\n");
+
+		vTaskDelay(500);
+	}
 
 	inputBuffer.size = 0;
 
@@ -39,6 +61,8 @@ extern void FSM(void *dummy){
 			UART_push_out("\r\n");
 		}
 
+		//Not working at the moment
+#warning "CRx command does not work yet. ADC value too high"
 		//CRx command
 		else if(strncmp(commandString, "CR", 2) == 0) {
 			uint16_t current = 0; //Current in mA
@@ -63,8 +87,15 @@ extern void FSM(void *dummy){
 
 			}
 
-			UART_push_out_len((char *)&current, 2);
+//			UART_push_out_len((char *)&current, 2);
+//			UART_push_out("\r\n");
+
+			//For debugging only
+			char output[6];
+			itoa(current, output, 10);
+			UART_push_out_len(output, 5);
 			UART_push_out("\r\n");
+
 		}
 
 		//VTx command
@@ -77,8 +108,9 @@ extern void FSM(void *dummy){
 					voltage = Get_Battery_Voltage(Right_Battery);
 				}
 
-				UART_push_out_len((char *)&voltage, 1);
+				UART_push_out_len((char *)&voltage, 2);
 				UART_push_out("\r\n");
+
 		}
 
 		//BPx command
@@ -133,7 +165,10 @@ extern void FSM(void *dummy){
 
 		//PEX command
 		else if (strcmp(commandString, "PEX") == 0) {
+			uint16_t pressure = Get_External_Pressure();
 
+			UART_push_out_len((char *)&pressure, 2);
+			UART_push_out_len("\r\n", 2);
 		}
 
 		//catch all error

--- a/src/FSM.c
+++ b/src/FSM.c
@@ -9,6 +9,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 #include "ADC.h"
+#include "sensors.h"
 
 #define CHAR_TO_INT (48)
 
@@ -18,9 +19,8 @@ extern void FSM(void *dummy){
 
 	inputBuffer.size = 0;
 
-	//temporary storage to return from buffer
+	//Stores the current command
 	char commandString[MAX_BUFFER_SIZE] = "";
-	int tempVar;
 
 	while(1){
 		//it's important that this is while, if the task is accidentally awaken it
@@ -31,15 +31,89 @@ extern void FSM(void *dummy){
 		}
 		//Write a statement here to do a string comparison on commands
 		Buffer_pop(&inputBuffer, commandString);
-		char argument = commandString[3];
-		commandString[3] = '\0';
 
-		char tempOutputString[MAX_BUFFER_SIZE] = "";
+		//RID
+		if(strcmp(commandString, "RID") == 0){
+			UART_push_out("Power_");
+			UART_push_out("Board");
+			UART_push_out("\r\n");
+		}
+
+		//CRx command
+		else if(strncmp(commandString, "CR", 2) == 0) {
+			uint16_t current = 0; //Current in mA
+
+			if(commandString[2] == '1') {
+				//Battery 1
+				current = Get_Battery_Current(Left_Battery);
+
+			} else if(commandString[2] == '2') {
+				//Battery 2
+				current = Get_Battery_Current(Right_Battery);
+
+			} else if(commandString[2] == 'M') {
+				//Total Motor Current
+				//Uses I2C chip, Not implemented yet
+				current = Get_Motors_Current();
+
+			} else if(commandString[2] == 'S') {
+				//Total System current
+				//Uses I2C chip, Not implemented yet
+				current = Get_System_Current();
+
+			}
+
+			UART_push_out_len((char *)&current, 2);
+			UART_push_out("\r\n");
+		}
+
+		//VTx command
+		else if (strncmp(commandString, "VT", 2) == 0) {
+				uint16_t voltage = 0; //Voltage in mV
+
+				if (commandString[2] == '1') {
+					voltage = Get_Battery_Voltage(Left_Battery);
+				} else if (commandString[2] == '2') {
+					voltage = Get_Battery_Voltage(Right_Battery);
+				}
+
+				UART_push_out_len((char *)&voltage, 1);
+				UART_push_out("\r\n");
+		}
+
+		//BPx command
+		else if (strncmp(commandString, "BP", 2) == 0) {
+			if (commandString[2] == '1') {
+				//enable battery bridge
+			} else if (commandString[2] == '0') {
+				//disable battery bridge
+			}
+		}
+
+		//RBxyyy command
+		else if (strncmp(commandString, "RB", 2) == 0) {
+
+		}
+
+		//PxEx command
+		else if (commandString[0] == 'P' && commandString[2] == 'E') {
+
+		}
+
+		//TMP
+		else if (strcmp(commandString, "TMP") == 0) {
+
+		}
+
+		//HUM command
+		else if (strcmp(commandString, "HUM") == 0) {
+
+		}
 
 		//WTH
-		if(strcmp(commandString, "WTH") == 0){
+		else if(strcmp(commandString, "WTH") == 0){
 			char bufs[5];
-			uint16_t pressure = Get_ADC_Channel(ADC_Water_Sensor);
+			uint16_t pressure = Get_Water_Sensor_Value();
 			itoa(pressure, bufs, 10);
 			UART_push_out_len(bufs, 5);
 			UART_push_out_len("\r\n", 2);
@@ -47,17 +121,21 @@ extern void FSM(void *dummy){
 
 		//WTR
 		else if(strcmp(commandString, "WTR") == 0){
-			uint16_t pressure = Get_ADC_Channel(ADC_Water_Sensor);
+			uint16_t pressure = Get_Water_Sensor_Value();
 			UART_push_out_len((char *)&pressure, 2);
 			UART_push_out_len("\r\n", 2);
 		}
 
-		//RID
-		else if(strcmp(commandString, "RID") == 0){
-			UART_push_out("Power_");
-			UART_push_out("Board");
-			UART_push_out("\r\n");
+		//PIN command
+		else if (strcmp(commandString, "PIN") == 0) {
+
 		}
+
+		//PEX command
+		else if (strcmp(commandString, "PEX") == 0) {
+
+		}
+
 		//catch all error
 		else{
 			UART_push_out("error: ");

--- a/src/FSM.c
+++ b/src/FSM.c
@@ -31,7 +31,8 @@ extern void FSM(void *dummy){
 			//sleeps the task into it is notified to continue
 			ulTaskNotifyTake( pdTRUE, portMAX_DELAY );
 		}
-		//Write a statement here to do a string comparison on commands
+
+		memset(commandString, 0, MAX_BUFFER_SIZE);
 		Buffer_pop(&inputBuffer, commandString);
 
 		//RID
@@ -94,32 +95,45 @@ extern void FSM(void *dummy){
 			} else if (commandString[2] == '0') {
 				//disable battery bridge
 			}
+
+			//Returns ACK for now so software can begin testing
+			UART_push_out("ACK\r\n");
 		}
 
-		//RBxyyy command
+		//RBxyyy command, Reboot Subsystem
 		else if (strncmp(commandString, "RB", 2) == 0) {
 
+			//Returns ACK for now so software can begin testing
+			UART_push_out("ACK\r\n");
 		}
 
-		//PxEx command
+		//PxEx command, Power Motor/System Enable/Disable
 		else if (commandString[0] == 'P' && commandString[2] == 'E') {
 
+			//Returns ACK for now so software can begin testing
+			UART_push_out("ACK\r\n");
 		}
 
-		//TMP
+		//TMP command, Temperature
 		else if (strcmp(commandString, "TMP") == 0) {
+			uint16_t temperature = Get_Temperature();
 
+			UART_push_out_len((char *)&temperature, 2);
+			UART_push_out("\r\n");
 		}
 
-		//HUM command
+		//HUM command, Humidity
 		else if (strcmp(commandString, "HUM") == 0) {
+			uint16_t humidity = Get_Temperature();
 
+			UART_push_out_len((char *)&humidity, 2);
+			UART_push_out("\r\n");
 		}
 
 		//Hardware issue with op-amp causes values below 45mV and values above 2.75V to return incorrect ADC values.
 		//WTH
 		else if(strcmp(commandString, "WTH") == 0){
-			char bufs[5];
+			char bufs[6] = "";
 			uint16_t pressure = Get_Water_Sensor_Value();
 			itoa(pressure, bufs, 10);
 			UART_push_out_len(bufs, 5);
@@ -130,13 +144,17 @@ extern void FSM(void *dummy){
 		//WTR
 		else if(strcmp(commandString, "WTR") == 0){
 			uint16_t pressure = Get_Water_Sensor_Value();
+
 			UART_push_out_len((char *)&pressure, 2);
 			UART_push_out_len("\r\n", 2);
 		}
 
 		//PIN command
 		else if (strcmp(commandString, "PIN") == 0) {
+			uint16_t pressure = Get_Temperature();
 
+			UART_push_out_len((char *)&pressure, 2);
+			UART_push_out("\r\n");
 		}
 
 		//Hardware issue with op-amp causes values below 45mV and values above 2.75V to return incorrect ADC values.

--- a/src/UART.c
+++ b/src/UART.c
@@ -14,7 +14,7 @@
 
 //Definitions
 #define MIN_COMMAND_LENGTH (4)
-#define MAX_COMMAND_LENGTH (5)
+#define MAX_COMMAND_LENGTH (6)
 
 #define MAX_OUPUT_DATA (10)
 

--- a/src/main.c
+++ b/src/main.c
@@ -53,9 +53,7 @@ void vGeneralTaskInit(void){
 		tskIDLE_PRIORITY + 1, // uxPriority
 		NULL              ); // pvCreatedTask */
 }
-int
-main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
 	//GPIO + ADC1 + DMA
 	initADC();
 	FSM_Init();

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -17,9 +17,11 @@
 
 #define ADC_VALUE_TO_CURRENT	((float)121000/4095) //121000mA of current when pin is at 3.3V
 
-#define ADC_VALUE_TO_PRESSURE(x)	(((float)25/819)*(x) + 2.2) //millipsi
+// psi = (2500/819)*ADC_VALUE + 220  for 3.3V supply to sensor
+// psi = (2500/1241)*ADC_VALUE + 220  for 5V supply to sensor
+#define ADC_VALUE_TO_PRESSURE(x)	(((float)2500/1241)*(x) + 220) //10^2 psi, hecto-psi
 
-// Returns value in mVd
+// Returns value in mV
 extern uint16_t Get_Battery_Voltage(battery_t battery) {
 	//It would be nice to have decimal places
 	uint16_t voltage = 0;
@@ -63,7 +65,6 @@ extern uint16_t Get_External_Pressure() {
 	uint16_t pressure = Get_ADC_Channel(ADC_Pressure_Sensor);
 	pressure = ADC_VALUE_TO_PRESSURE(pressure);
 	return pressure;
-
 }
 
 extern uint16_t Get_Internal_Pressure() {

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -19,7 +19,7 @@
 
 // psi = (2500/819)*ADC_VALUE + 220  for 3.3V supply to sensor
 // psi = (2500/1241)*ADC_VALUE + 220  for 5V supply to sensor
-#define ADC_VALUE_TO_PRESSURE(x)	(((float)2500/1241)*(x) + 220) //10^2 psi, hecto-psi
+#define ADC_VALUE_TO_PRESSURE(x)	(((float)2500/1241)*(x) + 220) //10^(-2) psi, hecto-psi
 
 // Returns value in mV
 extern uint16_t Get_Battery_Voltage(battery_t battery) {
@@ -54,11 +54,17 @@ extern uint16_t Get_Battery_Current(battery_t battery) {
 //Returns value in mA
 extern uint16_t Get_System_Current() {
 	//This uses an I2C device
+	//Returns constant for now so software can start testing
+
+	return 0x00FF;
 }
 
 //Returns value in mA
 extern uint16_t Get_Motors_Current() {
 	//This uses an I2C device
+	//Returns constant for now so software can start testing
+
+	return 0x00FF;
 }
 
 extern uint16_t Get_External_Pressure() {
@@ -69,14 +75,23 @@ extern uint16_t Get_External_Pressure() {
 
 extern uint16_t Get_Internal_Pressure() {
 	//This uses an I2C device
+	//Returns constant for now so software can start testing
+
+	return 0x00FF;
 }
 
 extern uint16_t Get_Temperature() {
 	//This uses an I2C device
+	//Returns constant for now so software can start testing
+
+	return 0x00FF;
 }
 
 extern uint16_t Get_Humidity() {
 	//This uses an I2C device
+	//Returns constant for now so software can start testing
+
+	return 0x00FF;
 }
 
 extern uint16_t Get_Water_Sensor_Value() {

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -13,14 +13,16 @@
 //Defines for calculations
 #define ADC_TO_PIN_VOLTAGE (3.3/4095)
 
-#define ADC_TO_BAT_VOLTAGE	(10090 * ADC_TO_PIN_VOLTAGE)
+#define ADC_VALUE_TO_BAT_VOLTAGE	(10090 * ADC_TO_PIN_VOLTAGE) //mV
 
-#define ADC_TO_CURRENT	(((float)121000/4096) * ADC_TO_PIN_VOLTAGE) //121000mA of current when pin is at 3.3V
+#define ADC_VALUE_TO_CURRENT	((float)121000/4095) //121000mA of current when pin is at 3.3V
 
-// Returns value in mV
+#define ADC_VALUE_TO_PRESSURE(x)	(((float)25/819)*(x) + 2.2) //millipsi
+
+// Returns value in mVd
 extern uint16_t Get_Battery_Voltage(battery_t battery) {
 	//It would be nice to have decimal places
-	uint8_t voltage = 0;
+	uint16_t voltage = 0;
 
 	if(battery == Left_Battery) {
 		voltage = Get_ADC_Channel(ADC_Left_Bat_Voltage);
@@ -28,14 +30,14 @@ extern uint16_t Get_Battery_Voltage(battery_t battery) {
 		voltage = Get_ADC_Channel(ADC_Right_Bat_Voltage);
 	}
 
-	voltage = ADC_TO_BAT_VOLTAGE * voltage;
+	voltage = ADC_VALUE_TO_BAT_VOLTAGE * voltage; //Could be different from actual value due to variation is resistance.
 	return voltage;
 }
 
 //Returns value in mA
 extern uint16_t Get_Battery_Current(battery_t battery) {
 	//It would be nice to have decimal places
-	uint8_t current = 0;
+	uint16_t current = 0;
 
 	if(battery == Left_Battery) {
 		current = Get_ADC_Channel(ADC_Left_Bat_Current);
@@ -43,7 +45,7 @@ extern uint16_t Get_Battery_Current(battery_t battery) {
 		current = Get_ADC_Channel(ADC_Right_Bat_Current);
 	}
 
-	current = ADC_TO_CURRENT * current;
+	current = ADC_VALUE_TO_CURRENT * current;
 	return current;
 }
 
@@ -58,7 +60,10 @@ extern uint16_t Get_Motors_Current() {
 }
 
 extern uint16_t Get_External_Pressure() {
-	//This uses ADC
+	uint16_t pressure = Get_ADC_Channel(ADC_Pressure_Sensor);
+	pressure = ADC_VALUE_TO_PRESSURE(pressure);
+	return pressure;
+
 }
 
 extern uint16_t Get_Internal_Pressure() {

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -1,0 +1,78 @@
+/*
+ * sensors.c
+ *
+ *  Created on: May 11, 2018
+ *      Author: Poornachander
+ */
+
+#include "stm32f0xx.h"
+#include "sensors.h"
+#include "ADC.h"
+
+//ADC is 12-bit right aligned
+//Defines for calculations
+#define ADC_TO_PIN_VOLTAGE (3.3/4095)
+
+#define ADC_TO_BAT_VOLTAGE	(10090 * ADC_TO_PIN_VOLTAGE)
+
+#define ADC_TO_CURRENT	(((float)121000/4096) * ADC_TO_PIN_VOLTAGE) //121000mA of current when pin is at 3.3V
+
+// Returns value in mV
+extern uint16_t Get_Battery_Voltage(battery_t battery) {
+	//It would be nice to have decimal places
+	uint8_t voltage = 0;
+
+	if(battery == Left_Battery) {
+		voltage = Get_ADC_Channel(ADC_Left_Bat_Voltage);
+	} else if (battery == Right_Battery) {
+		voltage = Get_ADC_Channel(ADC_Right_Bat_Voltage);
+	}
+
+	voltage = ADC_TO_BAT_VOLTAGE * voltage;
+	return voltage;
+}
+
+//Returns value in mA
+extern uint16_t Get_Battery_Current(battery_t battery) {
+	//It would be nice to have decimal places
+	uint8_t current = 0;
+
+	if(battery == Left_Battery) {
+		current = Get_ADC_Channel(ADC_Left_Bat_Current);
+	} else if (battery == Right_Battery) {
+		current = Get_ADC_Channel(ADC_Right_Bat_Current);
+	}
+
+	current = ADC_TO_CURRENT * current;
+	return current;
+}
+
+//Returns value in mA
+extern uint16_t Get_System_Current() {
+	//This uses an I2C device
+}
+
+//Returns value in mA
+extern uint16_t Get_Motors_Current() {
+	//This uses an I2C device
+}
+
+extern uint16_t Get_External_Pressure() {
+	//This uses ADC
+}
+
+extern uint16_t Get_Internal_Pressure() {
+	//This uses an I2C device
+}
+
+extern uint16_t Get_Temperature() {
+	//This uses an I2C device
+}
+
+extern uint16_t Get_Humidity() {
+	//This uses an I2C device
+}
+
+extern uint16_t Get_Water_Sensor_Value() {
+	return Get_ADC_Channel(ADC_Water_Sensor); //Very simple return for now. Functionality can be expanded later as needed.
+}


### PR DESCRIPTION
The commands parsing code for the Power Board is completed. The commands input and output syntax should match exactly what is in the Github wiki for the power board. For now, all I2C sensors will return a constant 0x00FF. This is so software can begin testing. That includes the following:
- Motor Current
- System Current
- Internal Pressure
- Temperature
- Humidity

ADC sensors with return actual values although there is a bug in the hardware so it might not return what the sensor is actually reading. Basically, any value below 45mV to the ADC will return a constant 45mV and any ADC values above 2.75V will a constant 2.75V. ADC sensors:
- Battery 1 and 2 current
- Water sensor
- External pressure sensor

The rest of the commands that enable/disable certain sections on the board will return "ACK\r\n", but it won't actually do what it says it will do. This will be completed on the hsd branch.